### PR TITLE
Support determination of if a report is part of nav.no or not

### DIFF
--- a/mock/server.ts
+++ b/mock/server.ts
@@ -685,7 +685,7 @@ api.get('/api/reports/123456789', (c) => {
     lastChanged: '2023-10-04T15:24:18.000Z',
     notes: 'Dette er en testrapport',
     hasWriteAccess: true,
-    isPartOfNavNo: true,
+    isPartOfNavNo: false,
   };
 
   return c.json(initializedReport); // Send the custom object as the response

--- a/mock/server.ts
+++ b/mock/server.ts
@@ -112,6 +112,31 @@ api.get('api/users/details', (c) => {
   });
 });
 
+api.get('api/user', (c) => {
+  return c.json({
+    email: 'my.user@nav.no',
+    name: 'Hakaurlander, JasMaNi',
+    teams: teams,
+    isAdmin: true,
+    reports: [
+      {
+        title: 'Ayyyy',
+        id: '12erh34',
+        teamId: 'team-ultratull',
+        teamName: 'Team Ultratull',
+        date: '2024-07-15',
+      },
+      {
+        title: 'Heihei',
+        id: '12erh42',
+        teamId: 'team-tull',
+        teamName: 'Team Tull',
+        date: '2024-08-19',
+      },
+    ],
+  });
+});
+
 api.get('api/teams/team-nav/details', (c) => {
   return c.json({
     id: 'team-nav',

--- a/mock/server.ts
+++ b/mock/server.ts
@@ -683,7 +683,9 @@ api.get('/api/reports/123456789', (c) => {
     ],
     created: '2023-10-04T15:24:18.000Z',
     lastChanged: '2023-10-04T15:24:18.000Z',
+    notes: 'Dette er en testrapport',
     hasWriteAccess: true,
+    isPartOfNavNo: true,
   };
 
   return c.json(initializedReport); // Send the custom object as the response

--- a/src/components/Modal/createReportModal/CreateReportModal.tsx
+++ b/src/components/Modal/createReportModal/CreateReportModal.tsx
@@ -1,5 +1,5 @@
-import { useRef, useState } from 'react';
-import { Button, Modal, Select, TextField } from '@navikt/ds-react';
+import { useRef, useState, useEffect } from 'react';
+import { Button, Modal, Select, TextField, Checkbox } from '@navikt/ds-react';
 import { createReport } from '@src/services/reportServices';
 import { FilePlusIcon } from '@navikt/aksel-icons';
 import { fetcher } from '@src/utils/client/api.ts';
@@ -14,6 +14,7 @@ const CreateReportModal = () => {
     name: '',
     urlTilSiden: '',
     teamId: '',
+    isPartOfNavNo: true,
   });
   const handleSubmit = () => {
     const reportId = createReport(reportDetails);
@@ -35,9 +36,15 @@ const CreateReportModal = () => {
     });
   };
 
+  const handleCheckboxChange = () => {
+    setReportDetails({
+      ...reportDetails,
+      isPartOfNavNo: !reportDetails.isPartOfNavNo,
+    });
+  };
+
   const isValid =
     reportDetails.name && reportDetails.urlTilSiden && reportDetails.teamId;
-
   return (
     <div>
       <Button
@@ -62,7 +69,6 @@ const CreateReportModal = () => {
             id="title"
             name="name"
             onChange={handleChange}
-            required
           />
           <TextField
             label="URL"
@@ -70,13 +76,19 @@ const CreateReportModal = () => {
             id="url"
             name="urlTilSiden"
             onChange={handleChange}
-            required
           />
+          <Checkbox
+            description="Hvis rapporten er for en applikasjon som er en del av NAV.no, huk av her."
+            name="isPartOfNavNo"
+            onChange={handleCheckboxChange}
+            value={!reportDetails.isPartOfNavNo}
+          >
+            Ikke en del av NAV.no
+          </Checkbox>
           <Select
             label="Hvilket team er ansvarlig for løsningen?"
             name="teamId"
             onChange={handleChange}
-            required
           >
             <option value="">Velg team</option>
             {userDetails?.teams.map((team: Team) => (

--- a/src/components/aggregated-reports/CreateAggregatedReport.tsx
+++ b/src/components/aggregated-reports/CreateAggregatedReport.tsx
@@ -6,20 +6,16 @@ import {
   Textarea,
   TextField,
 } from '@navikt/ds-react';
-import type { AggregatedReport, InitializeAggregatedReport } from '@src/types';
+import type {
+  AggregatedReport,
+  InitializeAggregatedReport,
+  ReportSummary,
+} from '@src/types';
 import { createAggregatedReport } from '@src/services/reportServices';
 import styles from './CreateAggregatedReport.module.css';
 
-interface Report {
-  title: string;
-  id: string;
-  teamName: string;
-  teamId: string;
-  date: string;
-}
-
 interface ReportListProps {
-  reports: Report[];
+  reports: ReportSummary[];
   aggregatedReport?: AggregatedReport;
 }
 
@@ -71,7 +67,7 @@ const Reports = ({ reports, aggregatedReport }: ReportListProps) => {
           });
         }}
       >
-        {reports.map((report: Report) => (
+        {reports.map((report: ReportSummary) => (
           <Checkbox value={report.id} key={report.id}>
             {report.title}
           </Checkbox>

--- a/src/components/reportPages/CreateReport.tsx
+++ b/src/components/reportPages/CreateReport.tsx
@@ -93,6 +93,7 @@ const CreateReport = ({ report, reportType, isAdmin }: CreateReportProps) => {
 
   useEffect(() => {
     setCriteriaData(report.successCriteria);
+    setIsPartOfNavNo(report.isPartOfNavNo);
   }, [report]);
 
   useEffect(() => {
@@ -212,7 +213,7 @@ const CreateReport = ({ report, reportType, isAdmin }: CreateReportProps) => {
             <Checkbox
               description="Hvis rapporten er for en applikasjon som er en del av NAV.no, huk av her."
               name="isPartOfNavNo"
-              value={!isPartOfNavNo}
+              defaultChecked={!isPartOfNavNo}
               onChange={handleCheckboxChange}
             >
               Ikke en del av NAV.no

--- a/src/components/reportPages/CreateReport.tsx
+++ b/src/components/reportPages/CreateReport.tsx
@@ -93,6 +93,11 @@ const CreateReport = ({ report, reportType, isAdmin }: CreateReportProps) => {
     updateReportData({ isPartOfNavNo: !isPartOfNavNo });
   };
 
+  useEffect(() => {
+    setCriteriaData(report.successCriteria);
+    setIsPartOfNavNo(report.isPartOfNavNo);
+  }, [report]);
+
   return (
     <div className={styles.reportContent}>
       <Heading level="1" size="xlarge">

--- a/src/components/reportPages/CreateReport.tsx
+++ b/src/components/reportPages/CreateReport.tsx
@@ -47,7 +47,6 @@ const CreateReport = ({ report, reportType, isAdmin }: CreateReportProps) => {
       reportType === 'SINGLE'
         ? await updateReport(report.reportId, updates)
         : await updateAggregatedReport(report.reportId, updates);
-      console.log('Report updated');
     } catch (error) {
       console.error(error);
     }
@@ -90,13 +89,15 @@ const CreateReport = ({ report, reportType, isAdmin }: CreateReportProps) => {
 
   const handleCheckboxChange = () => {
     setIsPartOfNavNo(!isPartOfNavNo);
-    updateReportData({ isPartOfNavNo: isPartOfNavNo });
   };
 
   useEffect(() => {
     setCriteriaData(report.successCriteria);
-    setIsPartOfNavNo(report.isPartOfNavNo);
   }, [report]);
+
+  useEffect(() => {
+    updateReportData({ isPartOfNavNo: isPartOfNavNo });
+  }, [isPartOfNavNo]);
 
   return (
     <div className={styles.reportContent}>

--- a/src/components/reportPages/CreateReport.tsx
+++ b/src/components/reportPages/CreateReport.tsx
@@ -90,7 +90,7 @@ const CreateReport = ({ report, reportType, isAdmin }: CreateReportProps) => {
 
   const handleCheckboxChange = () => {
     setIsPartOfNavNo(!isPartOfNavNo);
-    updateReportData({ isPartOfNavNo: !isPartOfNavNo });
+    updateReportData({ isPartOfNavNo: isPartOfNavNo });
   };
 
   useEffect(() => {

--- a/src/components/reportPages/CreateReport.tsx
+++ b/src/components/reportPages/CreateReport.tsx
@@ -4,15 +4,16 @@ import type { AggregatedReport, CriterionType, Report } from '@src/types.ts';
 import {
   updateAggregatedReport,
   updateReport,
-  deleteReport,
 } from '@src/services/reportServices';
 import {
   Tabs,
   TextField,
+  Textarea,
   Chips,
   Heading,
   Link,
   Button,
+  Checkbox,
 } from '@navikt/ds-react';
 import _ from 'lodash';
 import styles from './CreateReport.module.css';
@@ -80,7 +81,7 @@ const CreateReport = ({ report, reportType, isAdmin }: CreateReportProps) => {
   );
 
   const handleMetadataChange = _.debounce(
-    (fieldToUpdate: string, updatedData: string) => {
+    (fieldToUpdate: string, updatedData: string | boolean) => {
       updateReportData({ [fieldToUpdate]: updatedData });
     },
     500,
@@ -139,14 +140,6 @@ const CreateReport = ({ report, reportType, isAdmin }: CreateReportProps) => {
               </Button>
             )}
           </span>
-          <section className={styles.metadata}>
-            {report?.created && <p>Opprettet: {formatDate(report?.created)}</p>}
-            <p>Opprettet av: {report?.author.email}</p>
-            {report?.lastChanged && (
-              <p>Sist endret: {formatDate(report?.lastChanged)}</p>
-            )}
-            <p>Sist endret av: {report?.lastUpdatedBy}</p>
-          </section>
           <ul className={styles.criteriaList}>
             {selectedFilters.length === 0
               ? criteriaData.map((criterion) => (
@@ -176,6 +169,14 @@ const CreateReport = ({ report, reportType, isAdmin }: CreateReportProps) => {
           </ul>
         </Tabs.Panel>
         <Tabs.Panel value="metadata" className={styles.tabContent}>
+          <section className={styles.metadata}>
+            {report?.created && <p>Opprettet: {formatDate(report?.created)}</p>}
+            <p>Opprettet av: {report?.author.email}</p>
+            {report?.lastChanged && (
+              <p>Sist endret: {formatDate(report?.lastChanged)}</p>
+            )}
+            <p>Sist endret av: {report?.lastUpdatedBy}</p>
+          </section>
           <TextField
             label="Rapportnavn"
             id="report-name"
@@ -194,6 +195,26 @@ const CreateReport = ({ report, reportType, isAdmin }: CreateReportProps) => {
             readOnly={!report?.hasWriteAccess}
             onChange={(e) => handleMetadataChange('url', e.target.value)}
           />
+          <Textarea
+            label="Notater"
+            id="notes"
+            name="notes"
+            defaultValue={report?.notes}
+            readOnly={!report?.hasWriteAccess}
+            onChange={(e) => handleMetadataChange('notes', e.target.value)}
+          />
+          {reportType === 'SINGLE' && (
+            <Checkbox
+              description="Hvis rapporten er for en applikasjon som er en del av NAV.no, huk av her."
+              name="isPartOfNavNo"
+              checked={report?.isPartOfNavNo}
+              onChange={() =>
+                handleMetadataChange('isPartOfNavNo', !report?.isPartOfNavNo)
+              }
+            >
+              Ikke en del av NAV.no
+            </Checkbox>
+          )}
         </Tabs.Panel>
       </Tabs>
     </div>

--- a/src/components/reportPages/CreateReport.tsx
+++ b/src/components/reportPages/CreateReport.tsx
@@ -15,7 +15,7 @@ import {
   Button,
   Checkbox,
 } from '@navikt/ds-react';
-import _ from 'lodash';
+import _, { set } from 'lodash';
 import styles from './CreateReport.module.css';
 import { formatDate } from '@src/utils/client/date';
 import { ArrowRightIcon } from '@navikt/aksel-icons';
@@ -31,6 +31,7 @@ const CreateReport = ({ report, reportType, isAdmin }: CreateReportProps) => {
   const [criteriaData, setCriteriaData] = useState<CriterionType[]>([]);
   const [activeTab, setActiveTab] = useState('criteria');
   const [selectedFilters, setSelectedFilters] = useState<string[]>([]);
+  const [isPartOfNavNo, setIsPartOfNavNo] = useState(report.isPartOfNavNo);
 
   const filterOptions: Record<string, string> = {
     COMPLIANT: 'Tilfredsstilt',
@@ -81,19 +82,17 @@ const CreateReport = ({ report, reportType, isAdmin }: CreateReportProps) => {
   );
 
   const handleMetadataChange = _.debounce(
-    (fieldToUpdate: string, updatedData: string | boolean) => {
+    (fieldToUpdate: string, updatedData: string) => {
       updateReportData({ [fieldToUpdate]: updatedData });
     },
     500,
   );
 
-  useEffect(() => {
-    if (report) {
-      setCriteriaData(report.successCriteria);
-    }
-  }, [report]);
+  const handleCheckboxChange = () => {
+    setIsPartOfNavNo(!isPartOfNavNo);
+    updateReportData({ isPartOfNavNo: !isPartOfNavNo });
+  };
 
-  console.log('report', report);
   return (
     <div className={styles.reportContent}>
       <Heading level="1" size="xlarge">
@@ -207,10 +206,8 @@ const CreateReport = ({ report, reportType, isAdmin }: CreateReportProps) => {
             <Checkbox
               description="Hvis rapporten er for en applikasjon som er en del av NAV.no, huk av her."
               name="isPartOfNavNo"
-              checked={report?.isPartOfNavNo}
-              onChange={() =>
-                handleMetadataChange('isPartOfNavNo', !report?.isPartOfNavNo)
-              }
+              value={isPartOfNavNo}
+              onChange={() => handleCheckboxChange}
             >
               Ikke en del av NAV.no
             </Checkbox>

--- a/src/components/reportPages/CreateReport.tsx
+++ b/src/components/reportPages/CreateReport.tsx
@@ -28,7 +28,9 @@ interface CreateReportProps {
 }
 
 const CreateReport = ({ report, reportType, isAdmin }: CreateReportProps) => {
-  const [criteriaData, setCriteriaData] = useState<CriterionType[]>([]);
+  const [criteriaData, setCriteriaData] = useState<CriterionType[]>(
+    report.successCriteria,
+  );
   const [activeTab, setActiveTab] = useState('criteria');
   const [selectedFilters, setSelectedFilters] = useState<string[]>([]);
   const [isPartOfNavNo, setIsPartOfNavNo] = useState(report.isPartOfNavNo);
@@ -90,11 +92,6 @@ const CreateReport = ({ report, reportType, isAdmin }: CreateReportProps) => {
   const handleCheckboxChange = () => {
     setIsPartOfNavNo(!isPartOfNavNo);
   };
-
-  useEffect(() => {
-    setCriteriaData(report.successCriteria);
-    setIsPartOfNavNo(report.isPartOfNavNo);
-  }, [report]);
 
   useEffect(() => {
     updateReportData({ isPartOfNavNo: isPartOfNavNo });

--- a/src/components/reportPages/CreateReport.tsx
+++ b/src/components/reportPages/CreateReport.tsx
@@ -211,8 +211,8 @@ const CreateReport = ({ report, reportType, isAdmin }: CreateReportProps) => {
             <Checkbox
               description="Hvis rapporten er for en applikasjon som er en del av NAV.no, huk av her."
               name="isPartOfNavNo"
-              value={isPartOfNavNo}
-              onChange={() => handleCheckboxChange}
+              value={!isPartOfNavNo}
+              onChange={handleCheckboxChange}
             >
               Ikke en del av NAV.no
             </Checkbox>

--- a/src/services/reportServices.ts
+++ b/src/services/reportServices.ts
@@ -42,7 +42,7 @@ export const getReport = async (url: string): Promise<Report> => {
 };
 
 export const updateReport = async (id: string, updates: Partial<Report>) => {
-  const response = await fetch(`${apiProxyUrl}/reports/${id}/update`, {
+  const response = await fetch(`${apiProxyUrl}/reports/${id}`, {
     method: 'PATCH',
     body: JSON.stringify(updates),
     credentials: 'include',

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,6 +57,8 @@ export type Report = {
   lastUpdatedBy: string;
   reportType: string;
   hasWriteAccess: boolean;
+  notes: string;
+  isPartOfNavNo: boolean;
 };
 
 export type ReportSummary = {
@@ -65,12 +67,14 @@ export type ReportSummary = {
   teamId: string;
   teamName: string;
   date: string;
+  isPartOfNavNo: boolean;
 };
 
 export type InitialReport = {
   name: string; // Changed to descriptiveName
   urlTilSiden: string; // Changed to url
   teamId: string; // Changed to just Id
+  isPartOfNavNo: boolean;
 };
 
 export type InitializeAggregatedReport = {
@@ -108,4 +112,5 @@ export type AggregatedReport = {
     },
   ];
   notes: string;
+  isPartOfNavNo: boolean;
 };


### PR DESCRIPTION
The user is now able to determine if a given report is part of the nav.no domain or not when creating a report. This can be changed in the metadata tab when the report is created.